### PR TITLE
Added Git default branch detection

### DIFF
--- a/git-lint.gemspec
+++ b/git-lint.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.cert_chain = [Gem.default_cert_path]
 
   spec.required_ruby_version = "~> 3.0"
-  spec.add_dependency "git_plus", "~> 0.2"
+  spec.add_dependency "git_plus", "~> 0.4"
   spec.add_dependency "pastel", "~> 0.7"
   spec.add_dependency "refinements", "~> 8.0"
   spec.add_dependency "runcom", "~> 7.0"

--- a/lib/git/lint/branches/environments/circle_ci.rb
+++ b/lib/git/lint/branches/environments/circle_ci.rb
@@ -15,7 +15,7 @@ module Git
           end
 
           def commits
-            repository.commits "origin/master..#{name}"
+            repository.commits "origin/#{repository.branch_default}..#{name}"
           end
 
           private

--- a/lib/git/lint/branches/environments/git_hub_action.rb
+++ b/lib/git/lint/branches/environments/git_hub_action.rb
@@ -15,7 +15,7 @@ module Git
           end
 
           def commits
-            repository.commits "origin/master..#{name}"
+            repository.commits "origin/#{repository.branch_default}..#{name}"
           end
 
           private

--- a/lib/git/lint/branches/environments/local.rb
+++ b/lib/git/lint/branches/environments/local.rb
@@ -15,7 +15,7 @@ module Git
           end
 
           def commits
-            repository.commits "master..#{name}"
+            repository.commits "#{repository.branch_default}..#{name}"
           end
 
           private

--- a/lib/git/lint/branches/environments/netlify_ci.rb
+++ b/lib/git/lint/branches/environments/netlify_ci.rb
@@ -21,7 +21,7 @@ module Git
           def commits
             shell.capture3 "git remote add -f origin #{environment["REPOSITORY_URL"]}"
             shell.capture3 "git fetch origin #{name}:#{name}"
-            repository.commits "origin/master..origin/#{name}"
+            repository.commits "origin/#{repository.branch_default}..origin/#{name}"
           end
 
           private

--- a/lib/git/lint/branches/environments/travis_ci.rb
+++ b/lib/git/lint/branches/environments/travis_ci.rb
@@ -20,7 +20,7 @@ module Git
 
           def commits
             prepare_project
-            repository.commits "origin/master..#{name}"
+            repository.commits "origin/#{repository.branch_default}..#{name}"
           end
 
           private
@@ -35,7 +35,7 @@ module Git
               shell.capture3 "git fetch original_branch #{name}:#{name}"
             end
 
-            shell.capture3 "git remote set-branches --add origin master"
+            shell.capture3 "git remote set-branches --add origin #{repository.branch_default}"
             shell.capture3 "git fetch"
           end
 

--- a/spec/lib/git/lint/branches/environments/circle_ci_spec.rb
+++ b/spec/lib/git/lint/branches/environments/circle_ci_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Git::Lint::Branches::Environments::CircleCI do
   subject(:branch) { described_class.new repository: repository }
 
-  let(:repository) { instance_spy GitPlus::Repository, branch_name: "test" }
+  let(:repository) { instance_spy GitPlus::Repository, branch_default: "main", branch_name: "test" }
 
   describe "#name" do
     it "answers Git branch name" do
@@ -16,7 +16,7 @@ RSpec.describe Git::Lint::Branches::Environments::CircleCI do
   describe "#commits" do
     it "uses specific start and finish range" do
       branch.commits
-      expect(repository).to have_received(:commits).with("origin/master..origin/test")
+      expect(repository).to have_received(:commits).with("origin/main..origin/test")
     end
   end
 end

--- a/spec/lib/git/lint/branches/environments/git_hub_action_spec.rb
+++ b/spec/lib/git/lint/branches/environments/git_hub_action_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Git::Lint::Branches::Environments::GitHubAction do
   subject(:branch) { described_class.new repository: repository }
 
-  let(:repository) { instance_spy GitPlus::Repository, branch_name: "test" }
+  let(:repository) { instance_spy GitPlus::Repository, branch_default: "main", branch_name: "test" }
 
   describe "#name" do
     it "answers Git branch name" do
@@ -16,7 +16,7 @@ RSpec.describe Git::Lint::Branches::Environments::GitHubAction do
   describe "#commits" do
     it "uses specific start and finish range" do
       branch.commits
-      expect(repository).to have_received(:commits).with("origin/master..origin/test")
+      expect(repository).to have_received(:commits).with("origin/main..origin/test")
     end
   end
 end

--- a/spec/lib/git/lint/branches/environments/local_spec.rb
+++ b/spec/lib/git/lint/branches/environments/local_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 RSpec.describe Git::Lint::Branches::Environments::Local do
   subject(:branch) { described_class.new repository: repository }
 
-  let(:repository) { instance_spy GitPlus::Repository, branch_name: "test" }
+  let(:repository) { instance_spy GitPlus::Repository, branch_default: "main", branch_name: "test" }
 
   describe "#name" do
     it "answers Git branch name" do
@@ -16,7 +16,7 @@ RSpec.describe Git::Lint::Branches::Environments::Local do
   describe "#commits" do
     it "uses specific start and finish range" do
       branch.commits
-      expect(repository).to have_received(:commits).with("master..test")
+      expect(repository).to have_received(:commits).with("main..test")
     end
   end
 end

--- a/spec/lib/git/lint/branches/environments/netlify_ci_spec.rb
+++ b/spec/lib/git/lint/branches/environments/netlify_ci_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Git::Lint::Branches::Environments::NetlifyCI do
   end
 
   let(:environment) { {"HEAD" => "test", "REPOSITORY_URL" => "https://www.example.com/test.git"} }
-  let(:repository) { instance_spy GitPlus::Repository }
+  let(:repository) { instance_spy GitPlus::Repository, branch_default: "main" }
   let(:shell) { class_spy Open3 }
 
   describe "#name" do
@@ -33,7 +33,7 @@ RSpec.describe Git::Lint::Branches::Environments::NetlifyCI do
 
     it "uses specific start and finish range" do
       branch.commits
-      expect(repository).to have_received(:commits).with("origin/master..origin/test")
+      expect(repository).to have_received(:commits).with("origin/main..origin/test")
     end
   end
 end

--- a/spec/lib/git/lint/branches/environments/travis_ci_spec.rb
+++ b/spec/lib/git/lint/branches/environments/travis_ci_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Git::Lint::Branches::Environments::TravisCI do
     described_class.new repository: repository, shell: shell, environment: environment
   end
 
-  let(:repository) { instance_spy GitPlus::Repository }
+  let(:repository) { instance_spy GitPlus::Repository, branch_default: "main" }
   let(:shell) { class_spy Open3 }
 
   describe "#name" do
@@ -41,7 +41,7 @@ RSpec.describe Git::Lint::Branches::Environments::TravisCI do
   describe "#commits" do
     context "with pull request branch and without slug" do
       let :shell do
-        class_spy Open3, capture3: ["git remote set-branches --add origin master", "git fetch"]
+        class_spy Open3, capture3: ["git remote set-branches --add origin main", "git fetch"]
       end
 
       let :environment do
@@ -53,7 +53,7 @@ RSpec.describe Git::Lint::Branches::Environments::TravisCI do
 
       it "uses specific start and finish range" do
         branch.commits
-        expect(repository).to have_received(:commits).with("origin/master..test_name")
+        expect(repository).to have_received(:commits).with("origin/main..test_name")
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Git::Lint::Branches::Environments::TravisCI do
 
       it "uses specific start and finish range" do
         branch.commits
-        expect(repository).to have_received(:commits).with("origin/master..test_name")
+        expect(repository).to have_received(:commits).with("origin/main..test_name")
       end
     end
   end


### PR DESCRIPTION
## Overview

Necessary to respect Git's default branch setting within a global or local configuration (i.e. `init.defaultBranch`).

## Details

- Resolves #5.
- See commits for details.
